### PR TITLE
Adding a failing test to catch the missing image stack

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -22,3 +22,14 @@ jobs:
           NOMAD_VAR_HOSTNAMES: '["iiif.ux-fnf-misc.archive.org"]'
           NOMAD_VAR_PORTS: '{8080 = "http"}'
           NOMAD_VAR_FORCE_PULL: 'true'
+  deploy:
+    environment:
+      name: development
+      url: https://archivelabs-iiif-archivelab-org-${{ env.BRANCH_NAME }}.ux-fnf-misc.archive.org
+    runs-on: ubuntu-latest
+    needs: cicd
+    steps:
+      - name: Checkout # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+        uses: actions/checkout@v2
+      - name: Export BRANCH_NAME # store branch name in $BRANCH_NAME
+        run: echo BRANCH_NAME=`git rev-parse --abbrev-ref HEAD` >> $GITHUB_ENV

--- a/iiify/resolver.py
+++ b/iiify/resolver.py
@@ -311,7 +311,14 @@ def create_manifest3(identifier, domain=None, page=None):
 
     if mediatype == 'texts':
         # Get bookreader metadata (mostly for filenames and height / width of image)
-        bookReaderURL = f"https://{metadata.get('server')}/BookReader/BookReaderJSIA.php?id={identifier}&itemPath={metadata.get('dir')}&server={metadata.get('server')}&format=jsonp&subPrefix={identifier}"
+        # subprefix can be different from the identifier use the scandata filename to find the correct prefix
+        # if not present fall back to identifier
+        subprefix = identifier
+        for fileMd in metadata['files']:
+            if fileMd['name'].endswith('_scandata.xml'):
+                subprefix = fileMd['name'].replace('_scandata.xml', '')
+
+        bookReaderURL = f"https://{metadata.get('server')}/BookReader/BookReaderJSIA.php?id={identifier}&itemPath={metadata.get('dir')}&server={metadata.get('server')}&format=jsonp&subPrefix={subprefix}"
 
         print (f'Book reader url: {bookReaderURL}')
         bookreader = requests.get(bookReaderURL).json()

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -32,5 +32,12 @@ class TestManifests(unittest.TestCase):
         self.assertEqual(len(manifest['items']),1,f"Expected 1 canvas but got: {len(manifest['items'])}")
 
 
+    def test_v3_vermont_Life_Magazine(self):
+        resp = self.test_app.get("/iiif/3/rbmsbk_ap2-v4_2001_V55N4/manifest.json")
+        self.assertEqual(resp.status_code, 200)
+        manifest = resp.json
+
+        self.assertEqual(len(manifest['items']),116,f"Expected 116 canvas but got: {len(manifest['items'])}")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixed link:

https://archivelabs-iiif-archivelab-org-issue-120.ux-fnf-misc.archive.org/iiif/3/rbmsbk_ap2-v4_2001_V55N4/manifest.json