### PR TITLE
Add ia logo

### DIFF
--- a/iiify/resolver.py
+++ b/iiify/resolver.py
@@ -285,7 +285,19 @@ def addMetadata(item, identifier, metadata, collection=False):
 
     item.provider = [{"id": "https://archive.org",
                          "type": "Agent",
-                         "label": {"en": ["The Internet Archive"]}}]
+                         "label": {"en": ["The Internet Archive"]},
+                      "homepage": [{"id": "https://archive.org",
+                         "type": "Text",
+                         "label": {"en": ["Internet Archive Homepage"]},
+                         "format": "text/html"}],
+                      "logo": [{
+                          "id": "https://archive.org/images/glogo.png",
+                          "type": "Image",
+                          "format": "image/png",
+                          "height": 79,
+                          "width": 79
+                            }],
+                         }]
 
     if "licenseurl" in metadata:
         item.rights = metadata["licenseurl"].replace("https", "http", 1)

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -13,7 +13,7 @@ class TestCollections(unittest.TestCase):
         collection = resp.json
 
         self.assertEqual(collection['type'], "Collection", f"Unexpected type. Expected collection got {collection['type']}")
-        self.assertEqual(len(collection['items']),1001,f"Expected 1000 items but got: {len(collection['items'])}")
+        self.assertEqual(len(collection['items']),1001,f"Expected 1001 items but got: {len(collection['items'])}")
         self.assertEqual(collection['items'][-1]['type'],'Collection',"Expected last item to be a collection pointing to the next set of results")
 
 

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -85,6 +85,13 @@ class TestManifests(unittest.TestCase):
         self.assertEqual(len(manifest['items']),38,f"Expected 38 canvases but got: {len(manifest['items'])}")
         self.assertEqual("AIFF".lower() in resp.text.lower(), True, f"Expected the string 'AIFF'")
 
+    def test_provider_logo(self):
+        resp = self.test_app.get("/iiif/3/rashodgson68/manifest.json")
+        self.assertEqual(resp.status_code, 200)
+        manifest = resp.json
+        self.assertEqual(manifest['provider'][0]['homepage'][0]['id'] == "https://archive.org", True, f"Expected 'https://archive.org' but got {manifest['provider'][0]['id']}")
+        self.assertEqual(manifest['provider'][0]['logo'][0]['id'] == "https://archive.org/images/glogo.png", True, f"Expected logo URI but got {manifest['provider'][0]['logo'][0]['id']}")
+
 ''' to test:
 kaled_jalil (no derivatives)
 Dokku_obrash (geo-restricted?)


### PR DESCRIPTION
Fleshing out the `provider` block with homepage and logo for the Internet Archive